### PR TITLE
Fix 404 URLs on two profiles

### DIFF
--- a/_data/alum/nikkonikko.yaml
+++ b/_data/alum/nikkonikko.yaml
@@ -5,5 +5,5 @@ major: Computing Security
 graduation: 2017
 handle: nikkonikko
 forges:
-    GitHub: https://github.com/themidnightowl
+    GitHub: https://github.com/itsnikko
 bio: Securing your private bits over the Internet.

--- a/_data/faculty/deejoe.yaml
+++ b/_data/faculty/deejoe.yaml
@@ -1,6 +1,6 @@
 ---
 name: D. Joe
-blog: http://people.rit.edu/deejoe/planet/hfoss
+blog: https://people.rit.edu/djaigm/planet/hfoss/
 email: deejoe@mail.rit.edu
 major: Chemistry
 handle: dzho / deejoe


### PR DESCRIPTION
A couple of profiles had dead links that turned up when I added
html-proofer to our CI pipeline. This commit fixes those 404 URLs.