### PR TITLE
ci: Deploy built site from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,17 @@ script:
   - yamllint -c .yamllintrc _data/
   - bundle exec rake test
 
+deploy:
+  committer_from_gh: true
+  local_dir: "_site/"
+  provider: pages
+  skip_cleanup: true
+  target_branch: gh-pages
+  token: "$GITHUB_TOKEN"
+  on:
+    branch: master
+
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+    - secure: GU9wxFaHqPCpL1VKcVKPUVOmgPdmmhY4rHb4Rp5lQzdVgDblhutlMefmPeM+67fr374GM2H/f4mCu72gyQg2VpzHV2NsShE4RZ8WPv3qCgfw3mw2RwgMX0u9yq61CIDPzR4xS2prg+qxmfbiRnJdakNqgfcwYz4eyWpLbrEBReY=


### PR DESCRIPTION
Since I already did all this work, might as well do the last bit. This
commit adds a gated deployment from Travis. Nothing changes to the test
suite, but now, when the tests pass on `master`, the generated site
source in `_site/` will be pushed to the `gh-pages` branch. Once this
merges, I'll switch the repo to publish the content in that branch.

It's one way to make sure that if the tests ever fail and things get
messy in `master`, the bad content doesn't build unless tests actually
pass.