### PR TITLE
config: Set baseurl to `people` for CSS to render

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ task :test do
   options = {
     :check_html => true,
     :empty_alt_ignore => true,
+    :external_only => true,
     :http_status_ignore => [0,999],
     :cache => {
       :timeframe => '6w'

--- a/_config.yaml
+++ b/_config.yaml
@@ -18,6 +18,7 @@ github_username: FOSSRIT
 
 # --- general settings ---
 
+baseurl: /people
 lsi: false
 safe: true
 incremental: false


### PR DESCRIPTION
This fixes a bug by setting the `baseurl` setting in the config. We need
this since the site is served under a subdirectory of the main domain,
`fossrit.github.io`. The CSS should start rendering normally again after
this. My local test environment worked.

I had to disable external link checking on `htmlproofer` though. Not
happy about it, but I need some more clever way of fixing this.
`url_swap`?