### PR TITLE
workflows: Add inclusive-organization-action@v1.1.0

### DIFF
--- a/.github/workflows/invite-to-fossrit.yml
+++ b/.github/workflows/invite-to-fossrit.yml
@@ -1,0 +1,21 @@
+---
+- name: Inclusive Organization
+  on:
+    push:
+      branches: master
+  jobs:
+    invite:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Invite contributor to the organization
+          uses: lekterable/inclusive-organization-action@v1.1.0
+          with:
+            organization: FOSSRIT
+            team: friends-of-foss
+            comment: >
+              Thank you for contributing to the FOSSRIT/people repository. If
+              you have not already done so, consider adding a profile of your
+              own! As a token of our appreciation, here is an invite to the
+              FOSSRIT GitHub organization. See you around!
+          env:
+            ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
This GitHub Action will automatically send an invite to someone who
contributes a merged pull request to FOSSRIT/people. It invites them
specifically to @FOSSRIT/friends-of-foss, which is a view-only access
team. If they need a greater level of access, a human needs to add them
to another team manually.

This can be part of a FOSSbox on-boarding platform, in a way. :smile: