### PR TITLE
:bug: ci: Fix broken URLs caught by HTML-Proofer

### DIFF
--- a/_data/alum/friss.yaml
+++ b/_data/alum/friss.yaml
@@ -1,6 +1,6 @@
 ---
 name: Zach Friss
-blog: https://justdev.in
+blog: https://friss.me/
 email: foss@friss.me
 major: Computer Science
 graduation: 2016

--- a/_data/mentor/decause.yaml
+++ b/_data/mentor/decause.yaml
@@ -1,6 +1,6 @@
 ---
 name: Remy DeCausemaker
-blog: http://opensource.com/users/remyd
+blog: https://twitter.com/remy_d
 email: remyd@civx.us
 major: Multi-Discipinary Studies - Communications & Media Technnology, Public
        Policy

--- a/_data/student/galluccioProfile.yaml
+++ b/_data/student/galluccioProfile.yaml
@@ -1,8 +1,8 @@
 name: Olivia A. Gallucci
-blog: https://oliviagallucci.home.blog/
+blog: https://oliviagallucci.com/
 email: oag1356@rit.edu
 major: Computing Security
 graduation: 2025
 handle: kawedi
 forges:
-    GitHub: https://github.com/kawedi
+    GitHub: https://github.com/oliviagallucci


### PR DESCRIPTION
This updates two profiles so the CI pipeline will pass once again. It
would appear that `@kawedi` is now known as @oliviagallucci, and
Opensource.com author profiles are now private pages, so @decause can
have his Twitter profile as his blog in the interim.

This unblocks PRs #111 and #112.